### PR TITLE
dataclass in builder

### DIFF
--- a/builder/builder_api.py
+++ b/builder/builder_api.py
@@ -374,6 +374,12 @@ class Builder:
             else:
                 raise TypeError(f"Unsupported address type for {process_name}: {type(address)}. Registration failed.")
 
+    def add_process(self, process_id, name, config, path=None):
+        path = path or []
+        assert isinstance(process_id, str), f'Process id must be a string: {process_id}'
+        path.append(process_id)
+        self.node[path].add_process(name, config)
+
 
 
 def test_builder():
@@ -508,8 +514,10 @@ def test_pydantic():
     # get a pydantic model
     model = builder.get_pydantic_model('GillespieEvent')
     config = model(kdeg=1.0)
-    builder['event_process'].add_process(name='GillespieEvent', config=config)
+    # builder['event_process'].add_process(name='GillespieEvent', config=config)
+    builder.add_process(process_id='event_process', name='GillespieEvent', config=config, path=['down', 'here'])
 
+    builder
 
 
 if __name__ == '__main__':

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -14,8 +14,8 @@
    "id": "b385dca6-942d-472c-9963-13b8cb33843c",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-21T21:29:21.891373Z",
-     "start_time": "2024-01-21T21:29:13.531449Z"
+     "end_time": "2024-03-05T01:06:35.803193Z",
+     "start_time": "2024-03-05T01:06:35.164919Z"
     }
    },
    "outputs": [],
@@ -35,11 +35,68 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "b6260555-2bad-4834-adc5-e6d358063579",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:35.849027Z",
+     "start_time": "2024-03-05T01:06:35.804294Z"
+    }
+   },
    "outputs": [],
    "source": [
     "core = ProcessTypes()\n",
     "b = Builder(core=core)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0f177358-bab3-42ae-9a30-a76262d0a119",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:35.853468Z",
+     "start_time": "2024-03-05T01:06:35.849853Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<bigraph_schema.registry.Registry at 0x1063e72e0>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "core.process_registry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "504cdc74-56c3-473a-9ce8-1075de0d30d0",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:35.857458Z",
+     "start_time": "2024-03-05T01:06:35.854910Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<bigraph_schema.registry.TypeRegistry at 0x1062aec70>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "core.type_registry"
    ]
   },
   {
@@ -52,12 +109,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "30297af1-2d65-43d9-9ab7-0589d94a8cfe",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-21T21:29:21.896737Z",
-     "start_time": "2024-01-21T21:29:21.891980Z"
+     "end_time": "2024-03-05T01:06:35.860253Z",
+     "start_time": "2024-03-05T01:06:35.858381Z"
     }
    },
    "outputs": [],
@@ -66,6 +123,123 @@
     "    'default 1', {\n",
     "        '_inherit': 'float',\n",
     "        '_default': 1.0})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "fa947283-8520-422f-8891-662934bec059",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:35.863951Z",
+     "start_time": "2024-03-05T01:06:35.861010Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['integer',\n",
+       " '',\n",
+       " 'luminosity/length^2',\n",
+       " 'tuple',\n",
+       " 'current^2*time^3/length^2*mass',\n",
+       " 'length/time',\n",
+       " 'substance/length^3',\n",
+       " 'current*time/mass',\n",
+       " 'length^2*mass/temperature*time^2',\n",
+       " 'current*length*time',\n",
+       " 'step',\n",
+       " 'printing_unit/length',\n",
+       " 'wires',\n",
+       " 'current^2*time^4/length^2*mass',\n",
+       " 'length^2/time^2',\n",
+       " 'length^1_5*mass^0_5/time^2',\n",
+       " 'mass^0_5/length^0_5*time',\n",
+       " 'length*mass/time^2',\n",
+       " 'process',\n",
+       " 'length^3/mass*time^2',\n",
+       " 'tree',\n",
+       " 'length/mass',\n",
+       " 'length^2*mass/time^2',\n",
+       " '/substance',\n",
+       " 'length^4*mass/current*time^3',\n",
+       " 'substance',\n",
+       " 'length^0_5*mass^0_5/time',\n",
+       " 'length^2*mass/current^2*time^2',\n",
+       " 'time',\n",
+       " 'mass/length*time^2',\n",
+       " 'mass/current*time^2',\n",
+       " 'length^4*mass/time^3',\n",
+       " 'length^2*mass/current*time^2',\n",
+       " 'default 1',\n",
+       " 'list',\n",
+       " 'array',\n",
+       " 'length/time^2',\n",
+       " 'protocol',\n",
+       " 'length^2*mass/current^2*time^3',\n",
+       " 'current*time^2/length^2*mass',\n",
+       " 'length^3/time',\n",
+       " 'current*length^2',\n",
+       " 'length*mass/current*time^3',\n",
+       " 'temperature',\n",
+       " 'current',\n",
+       " 'length*mass/current^2*time^2',\n",
+       " 'current*length^2*time',\n",
+       " 'substance/time',\n",
+       " 'maybe',\n",
+       " 'length*time/mass',\n",
+       " 'printing_unit',\n",
+       " 'length^2*mass/time',\n",
+       " 'boolean',\n",
+       " 'mass^0_5/length^1_5',\n",
+       " 'number',\n",
+       " 'luminosity',\n",
+       " 'any',\n",
+       " 'map',\n",
+       " '/length',\n",
+       " 'length^2/time',\n",
+       " 'mass/temperature^4*time^3',\n",
+       " 'union',\n",
+       " 'length^3',\n",
+       " 'time^2/length',\n",
+       " 'length^1_5*mass^0_5/time',\n",
+       " 'length^2*mass/time^3',\n",
+       " 'length^2',\n",
+       " 'interval',\n",
+       " 'mass/length^3',\n",
+       " 'current*time',\n",
+       " 'current^2*time^4/length^3*mass',\n",
+       " 'float',\n",
+       " 'length',\n",
+       " 'schema',\n",
+       " '/printing_unit',\n",
+       " 'string',\n",
+       " 'path',\n",
+       " 'mass',\n",
+       " 'length^3*mass/current^2*time^4',\n",
+       " 'length^0_5*mass^0_5',\n",
+       " 'edge',\n",
+       " '/time',\n",
+       " 'length^2*mass/current*time^3',\n",
+       " 'current*time/substance',\n",
+       " 'mass/length',\n",
+       " '/temperature*time',\n",
+       " 'length^2*mass/substance*temperature*time^2',\n",
+       " 'mass/time^3',\n",
+       " 'length*temperature',\n",
+       " 'mass/length*time',\n",
+       " 'time/length',\n",
+       " 'mass/time^2']"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b.list_types()"
    ]
   },
   {
@@ -86,12 +260,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "id": "979e0bd85a31d4b0",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-21T21:29:21.984800Z",
-     "start_time": "2024-01-21T21:29:21.894599Z"
+     "end_time": "2024-03-05T01:06:35.867236Z",
+     "start_time": "2024-03-05T01:06:35.864659Z"
     },
     "collapsed": false,
     "jupyter": {
@@ -102,10 +276,10 @@
     {
      "data": {
       "text/plain": [
-       "['console-emitter', 'ram-emitter']"
+       "['ram-emitter', 'console-emitter']"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -124,9 +298,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "id": "5bff2ea4-42f9-430e-b1cc-f0581510ec8d",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:35.871137Z",
+     "start_time": "2024-03-05T01:06:35.867922Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from process_bigraph.experiments.minimal_gillespie import GillespieEvent\n",
@@ -144,9 +323,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "id": "f2893d4a-c13a-4d95-b85e-d5e9dce53a89",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:35.873904Z",
+     "start_time": "2024-03-05T01:06:35.871929Z"
+    }
+   },
    "outputs": [],
    "source": [
     "b.register_process(\n",
@@ -165,9 +349,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "id": "aec69dcc-471e-4c18-b22b-824cfe440e79",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:35.879127Z",
+     "start_time": "2024-03-05T01:06:35.876367Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@b.register_process('toy')\n",
@@ -202,21 +391,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "40cde984-cfdf-4571-af9c-3a3755e3763c",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:35.882531Z",
+     "start_time": "2024-03-05T01:06:35.879972Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['toy',\n",
-       " 'ram-emitter',\n",
+       "['console-emitter',\n",
        " 'GillespieInterval',\n",
+       " 'ram-emitter',\n",
        " 'GillespieEvent',\n",
-       " 'console-emitter']"
+       " 'toy']"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -243,9 +437,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "503863ee-0a58-44b3-accc-20e0167b947b",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:35.885338Z",
+     "start_time": "2024-03-05T01:06:35.883323Z"
+    }
+   },
    "outputs": [],
    "source": [
     "b['event_process'].add_process(\n",
@@ -256,9 +455,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "b094f1e5-5202-48d0-8bdd-57bbdded7fd1",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:35.956718Z",
+     "start_time": "2024-03-05T01:06:35.886159Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -269,59 +473,54 @@
        "<!-- Generated by graphviz version 9.0.0 (0)\n",
        " -->\n",
        "<!-- Title: bigraph Pages: 1 -->\n",
-       "<svg width=\"123pt\" height=\"200pt\"\n",
-       " viewBox=\"0.00 0.00 126.45 205.99\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
-       "<g id=\"graph0\" class=\"graph\" transform=\"scale(0.972222 0.972222) rotate(0) translate(4 201.99)\">\n",
+       "<svg width=\"180pt\" height=\"123pt\"\n",
+       " viewBox=\"0.00 0.00 185.58 126.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(0.972222 0.972222) rotate(0) translate(4 122)\">\n",
        "<title>bigraph</title>\n",
-       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-201.99 122.45,-201.99 122.45,4 -4,4\"/>\n",
-       "<!-- (&#39;event_process&#39;, &#39;interval&#39;) -->\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-122 181.58,-122 181.58,4 -4,4\"/>\n",
+       "<!-- (&#39;emitter&#39;,) -->\n",
        "<g id=\"node1\" class=\"node\">\n",
-       "<title>(&#39;event_process&#39;, &#39;interval&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"52.87\" cy=\"-25.92\" rx=\"25.92\" ry=\"25.92\"/>\n",
-       "<text text-anchor=\"start\" x=\"34.54\" y=\"-22.32\" font-family=\"Times,serif\" font-size=\"12.00\">interval</text>\n",
+       "<title>(&#39;emitter&#39;,)</title>\n",
+       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"54,-118 0,-118 0,-82 54,-82 54,-118\"/>\n",
+       "<text text-anchor=\"start\" x=\"10.01\" y=\"-96.4\" font-family=\"Times,serif\" font-size=\"12.00\">emitter</text>\n",
        "</g>\n",
        "<!-- (&#39;event_process&#39;,) -->\n",
        "<g id=\"node2\" class=\"node\">\n",
        "<title>(&#39;event_process&#39;,)</title>\n",
-       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"90.46,-124.84 15.28,-124.84 15.28,-88.84 90.46,-88.84 90.46,-124.84\"/>\n",
-       "<text text-anchor=\"start\" x=\"18.88\" y=\"-103.24\" font-family=\"Times,serif\" font-size=\"12.00\">event_process</text>\n",
-       "</g>\n",
-       "<!-- (&#39;event_process&#39;,)&#45;&gt;(&#39;event_process&#39;, &#39;interval&#39;) -->\n",
-       "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>(&#39;event_process&#39;,)&#45;&gt;(&#39;event_process&#39;, &#39;interval&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M52.87,-87.93C52.87,-77.47 52.87,-64.1 52.87,-52.54\"/>\n",
+       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"149.59,-36 74.41,-36 74.41,0 149.59,0 149.59,-36\"/>\n",
+       "<text text-anchor=\"start\" x=\"78.01\" y=\"-14.4\" font-family=\"Times,serif\" font-size=\"12.00\">event_process</text>\n",
        "</g>\n",
        "<!-- (&#39;event_process&#39;, &#39;m&#39;, &#39;R&#39;, &#39;N&#39;, &#39;A&#39;) -->\n",
        "<!-- (&#39;event_process&#39;, &#39;m&#39;, &#39;R&#39;, &#39;N&#39;, &#39;A&#39;)&#45;&gt;(&#39;event_process&#39;,) -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
        "<title>(&#39;event_process&#39;, &#39;m&#39;, &#39;R&#39;, &#39;N&#39;, &#39;A&#39;)&#45;&gt;(&#39;event_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M16.05,-175.21C6.81,-167.14 -4.1,-154.4 1.98,-142.84 3.8,-139.36 6.15,-136.17 8.83,-133.24\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"10.95,-136.04 15.98,-126.72 6.24,-130.87 10.95,-136.04\"/>\n",
-       "<text text-anchor=\"start\" x=\"2.87\" y=\"-144.84\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M75.32,-90.1C65.84,-81.06 54.46,-66.64 61.11,-54 62.94,-50.53 65.28,-47.33 67.96,-44.4\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"70.08,-47.2 75.11,-37.88 65.37,-42.03 70.08,-47.2\"/>\n",
+       "<text text-anchor=\"start\" x=\"61\" y=\"-56\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
        "</g>\n",
        "<!-- (&#39;event_process&#39;, &#39;m&#39;, &#39;R&#39;, &#39;N&#39;, &#39;A&#39;)&#45;&gt;(&#39;event_process&#39;,) -->\n",
-       "<g id=\"edge4\" class=\"edge\">\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
        "<title>(&#39;event_process&#39;, &#39;m&#39;, &#39;R&#39;, &#39;N&#39;, &#39;A&#39;)&#45;&gt;(&#39;event_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M34.92,-160C38.71,-148.99 43.16,-136.06 46.68,-125.83\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"31.72,-158.57 31.77,-169.16 38.33,-160.85 31.72,-158.57\"/>\n",
-       "<text text-anchor=\"start\" x=\"40.87\" y=\"-144.84\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M93.7,-75.31C97.7,-63.01 102.5,-48.22 106.19,-36.89\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"90.41,-74.12 90.65,-84.71 97.06,-76.28 90.41,-74.12\"/>\n",
+       "<text text-anchor=\"start\" x=\"100\" y=\"-56\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
        "</g>\n",
        "<!-- (&#39;event_process&#39;, &#39;D&#39;, &#39;N&#39;, &#39;A&#39;) -->\n",
        "<!-- (&#39;event_process&#39;, &#39;D&#39;, &#39;N&#39;, &#39;A&#39;)&#45;&gt;(&#39;event_process&#39;,) -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
        "<title>(&#39;event_process&#39;, &#39;D&#39;, &#39;N&#39;, &#39;A&#39;)&#45;&gt;(&#39;event_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M97.2,-172.26C90.49,-162.51 80.47,-147.95 71.65,-135.13\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"74.62,-133.28 66.07,-127.03 68.86,-137.25 74.62,-133.28\"/>\n",
-       "<text text-anchor=\"start\" x=\"82.87\" y=\"-144.84\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M156.55,-87.54C149.57,-76.8 138.86,-60.33 129.69,-46.22\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"132.87,-44.68 124.48,-38.21 127,-48.5 132.87,-44.68\"/>\n",
+       "<text text-anchor=\"start\" x=\"141\" y=\"-56\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
        "</g>\n",
        "</g>\n",
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x106c12c40>"
+       "<graphviz.graphs.Digraph at 0x10640bf70>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -341,9 +540,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "5ea31425-a8bb-45c3-a31d-77714cc8c137",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:35.960415Z",
+     "start_time": "2024-03-05T01:06:35.957772Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -370,23 +574,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "c9f462bb-5316-4724-aa8e-b3b71eb379b2",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:35.964314Z",
+     "start_time": "2024-03-05T01:06:35.961540Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Builder({ 'event_process': { '_type': 'process',\n",
+       "Builder({ 'emitter': { '_type': 'step',\n",
+       "               'address': 'local:ram-emitter',\n",
+       "               'config': {'emit': {}},\n",
+       "               'inputs': {},\n",
+       "               'instance': <process_bigraph.composite.RAMEmitter object at 0x1063e73d0>,\n",
+       "               'outputs': {}},\n",
+       "  'event_process': { '_type': 'process',\n",
        "                     'address': 'local:GillespieEvent',\n",
        "                     'config': {'kdeg': 1.0, 'ktsc': 5.0},\n",
        "                     'inputs': {'DNA': ['DNA_store'], 'mRNA': ['mRNA_store']},\n",
-       "                     'instance': <process_bigraph.experiments.minimal_gillespie.GillespieEvent object at 0x106c12dc0>,\n",
+       "                     'instance': <process_bigraph.experiments.minimal_gillespie.GillespieEvent object at 0x10640b790>,\n",
        "                     'interval': 1.0,\n",
        "                     'outputs': {'mRNA': ['mRNA_store']}}})"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -398,9 +613,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "79809baf-1d87-475a-b85f-3729f4716cb4",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:35.982919Z",
+     "start_time": "2024-03-05T01:06:35.965151Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -411,91 +631,86 @@
        "<!-- Generated by graphviz version 9.0.0 (0)\n",
        " -->\n",
        "<!-- Title: bigraph Pages: 1 -->\n",
-       "<svg width=\"252pt\" height=\"268pt\"\n",
-       " viewBox=\"0.00 0.00 259.23 275.31\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
-       "<g id=\"graph0\" class=\"graph\" transform=\"scale(0.972222 0.972222) rotate(0) translate(4 271.31)\">\n",
+       "<svg width=\"270pt\" height=\"181pt\"\n",
+       " viewBox=\"0.00 0.00 278.08 186.47\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(0.972222 0.972222) rotate(0) translate(4 182.47)\">\n",
        "<title>bigraph</title>\n",
-       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-271.31 255.23,-271.31 255.23,4 -4,4\"/>\n",
-       "<!-- (&#39;event_process&#39;, &#39;interval&#39;) -->\n",
-       "<g id=\"node1\" class=\"node\">\n",
-       "<title>(&#39;event_process&#39;, &#39;interval&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"72.08\" cy=\"-25.92\" rx=\"25.92\" ry=\"25.92\"/>\n",
-       "<text text-anchor=\"start\" x=\"53.76\" y=\"-22.32\" font-family=\"Times,serif\" font-size=\"12.00\">interval</text>\n",
-       "</g>\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-182.47 274.08,-182.47 274.08,4 -4,4\"/>\n",
        "<!-- (&#39;mRNA_store&#39;,) -->\n",
-       "<g id=\"node2\" class=\"node\">\n",
+       "<g id=\"node1\" class=\"node\">\n",
        "<title>(&#39;mRNA_store&#39;,)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"42.08\" cy=\"-225.23\" rx=\"42.08\" ry=\"42.08\"/>\n",
-       "<text text-anchor=\"start\" x=\"10.08\" y=\"-221.63\" font-family=\"Times,serif\" font-size=\"12.00\">mRNA_store</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"42.08\" cy=\"-136.39\" rx=\"42.08\" ry=\"42.08\"/>\n",
+       "<text text-anchor=\"start\" x=\"10.08\" y=\"-132.79\" font-family=\"Times,serif\" font-size=\"12.00\">mRNA_store</text>\n",
        "</g>\n",
        "<!-- (&#39;event_process&#39;,) -->\n",
        "<g id=\"node6\" class=\"node\">\n",
        "<title>(&#39;event_process&#39;,)</title>\n",
-       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"109.67,-130.99 34.5,-130.99 34.5,-94.99 109.67,-94.99 109.67,-130.99\"/>\n",
-       "<text text-anchor=\"start\" x=\"38.1\" y=\"-109.39\" font-family=\"Times,serif\" font-size=\"12.00\">event_process</text>\n",
+       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"109.67,-42.15 34.5,-42.15 34.5,-6.15 109.67,-6.15 109.67,-42.15\"/>\n",
+       "<text text-anchor=\"start\" x=\"38.1\" y=\"-20.55\" font-family=\"Times,serif\" font-size=\"12.00\">event_process</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,) -->\n",
-       "<g id=\"edge4\" class=\"edge\">\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
        "<title>(&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M21.11,-187.95C17.5,-177.14 16.28,-165.43 21.19,-155.14 24.01,-149.23 28.15,-143.9 32.86,-139.18\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"34.88,-142.06 40.06,-132.82 30.25,-136.81 34.88,-142.06\"/>\n",
-       "<text text-anchor=\"start\" x=\"22.08\" y=\"-157.14\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M21.11,-99.11C17.5,-88.3 16.28,-76.6 21.19,-66.31 24.01,-60.39 28.15,-55.06 32.86,-50.34\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"34.88,-53.22 40.06,-43.98 30.25,-47.97 34.88,-53.22\"/>\n",
+       "<text text-anchor=\"start\" x=\"22.08\" y=\"-68.31\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,) -->\n",
-       "<g id=\"edge6\" class=\"edge\">\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
        "<title>(&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M56.09,-172.74C60.08,-158.1 64.16,-143.11 67.2,-131.93\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"52.73,-171.78 53.48,-182.34 59.48,-173.61 52.73,-171.78\"/>\n",
-       "<text text-anchor=\"start\" x=\"61.08\" y=\"-157.14\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M56.09,-83.9C60.08,-69.26 64.16,-54.27 67.2,-43.1\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"52.73,-82.94 53.48,-93.51 59.48,-84.78 52.73,-82.94\"/>\n",
+       "<text text-anchor=\"start\" x=\"61.08\" y=\"-68.31\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,) -->\n",
-       "<g id=\"node3\" class=\"node\">\n",
+       "<g id=\"node2\" class=\"node\">\n",
        "<title>(&#39;DNA_store&#39;,)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"161.08\" cy=\"-225.23\" rx=\"36.96\" ry=\"36.96\"/>\n",
-       "<text text-anchor=\"start\" x=\"133.42\" y=\"-221.63\" font-family=\"Times,serif\" font-size=\"12.00\">DNA_store</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"161.08\" cy=\"-136.39\" rx=\"36.96\" ry=\"36.96\"/>\n",
+       "<text text-anchor=\"start\" x=\"133.42\" y=\"-132.79\" font-family=\"Times,serif\" font-size=\"12.00\">DNA_store</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;, &#39;A gene&#39;) -->\n",
-       "<g id=\"node4\" class=\"node\">\n",
+       "<g id=\"node3\" class=\"node\">\n",
        "<title>(&#39;DNA_store&#39;, &#39;A gene&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"161.08\" cy=\"-112.99\" rx=\"24.15\" ry=\"24.15\"/>\n",
-       "<text text-anchor=\"start\" x=\"144.25\" y=\"-109.39\" font-family=\"Times,serif\" font-size=\"12.00\">A gene</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"161.08\" cy=\"-24.15\" rx=\"24.15\" ry=\"24.15\"/>\n",
+       "<text text-anchor=\"start\" x=\"144.25\" y=\"-20.55\" font-family=\"Times,serif\" font-size=\"12.00\">A gene</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;A gene&#39;) -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
        "<title>(&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;A gene&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M161.08,-187.52C161.08,-171.24 161.08,-152.53 161.08,-138.06\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M161.08,-98.68C161.08,-82.4 161.08,-63.69 161.08,-49.22\"/>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;, &#39;B gene&#39;) -->\n",
-       "<g id=\"node5\" class=\"node\">\n",
+       "<g id=\"node4\" class=\"node\">\n",
        "<title>(&#39;DNA_store&#39;, &#39;B gene&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"227.08\" cy=\"-112.99\" rx=\"24.15\" ry=\"24.15\"/>\n",
-       "<text text-anchor=\"start\" x=\"210.25\" y=\"-109.39\" font-family=\"Times,serif\" font-size=\"12.00\">B gene</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"227.08\" cy=\"-24.15\" rx=\"24.15\" ry=\"24.15\"/>\n",
+       "<text text-anchor=\"start\" x=\"210.25\" y=\"-20.55\" font-family=\"Times,serif\" font-size=\"12.00\">B gene</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;B gene&#39;) -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
        "<title>(&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;B gene&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M180,-192.64C191.12,-174.06 204.87,-151.09 214.63,-134.78\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M180,-103.8C191.12,-85.22 204.87,-62.25 214.63,-45.95\"/>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,) -->\n",
-       "<g id=\"edge5\" class=\"edge\">\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
        "<title>(&#39;DNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M137.93,-195.55C124.2,-178.54 106.91,-157.13 93.5,-140.51\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"96.44,-138.59 87.44,-133.01 91,-142.99 96.44,-138.59\"/>\n",
-       "<text text-anchor=\"start\" x=\"112.08\" y=\"-157.14\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M137.93,-106.71C124.2,-89.7 106.91,-68.29 93.5,-51.68\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"96.44,-49.76 87.44,-44.17 91,-54.15 96.44,-49.76\"/>\n",
+       "<text text-anchor=\"start\" x=\"112.08\" y=\"-68.31\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
        "</g>\n",
-       "<!-- (&#39;event_process&#39;,)&#45;&gt;(&#39;event_process&#39;, &#39;interval&#39;) -->\n",
-       "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>(&#39;event_process&#39;,)&#45;&gt;(&#39;event_process&#39;, &#39;interval&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M72.08,-94.36C72.08,-82.29 72.08,-66.09 72.08,-52.6\"/>\n",
+       "<!-- (&#39;emitter&#39;,) -->\n",
+       "<g id=\"node5\" class=\"node\">\n",
+       "<title>(&#39;emitter&#39;,)</title>\n",
+       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"270.08,-154.39 216.08,-154.39 216.08,-118.39 270.08,-118.39 270.08,-154.39\"/>\n",
+       "<text text-anchor=\"start\" x=\"226.09\" y=\"-132.79\" font-family=\"Times,serif\" font-size=\"12.00\">emitter</text>\n",
        "</g>\n",
        "</g>\n",
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x106c12f10>"
+       "<graphviz.graphs.Digraph at 0x1063fff70>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -514,11 +729,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "f02c15797bdb73b8",
    "metadata": {
     "ExecuteTime": {
-     "start_time": "2024-01-21T21:29:21.997588Z"
+     "end_time": "2024-03-05T01:06:35.986588Z",
+     "start_time": "2024-03-05T01:06:35.983933Z"
     },
     "collapsed": false,
     "jupyter": {
@@ -534,11 +750,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "id": "aeb344bcd6a120ae",
    "metadata": {
     "ExecuteTime": {
-     "start_time": "2024-01-21T21:29:21.998661Z"
+     "end_time": "2024-03-05T01:06:36.006247Z",
+     "start_time": "2024-03-05T01:06:35.987494Z"
     },
     "collapsed": false,
     "jupyter": {
@@ -555,121 +772,116 @@
        "<!-- Generated by graphviz version 9.0.0 (0)\n",
        " -->\n",
        "<!-- Title: bigraph Pages: 1 -->\n",
-       "<svg width=\"375pt\" height=\"268pt\"\n",
-       " viewBox=\"0.00 0.00 385.66 275.31\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
-       "<g id=\"graph0\" class=\"graph\" transform=\"scale(0.972222 0.972222) rotate(0) translate(4 271.31)\">\n",
+       "<svg width=\"409pt\" height=\"181pt\"\n",
+       " viewBox=\"0.00 0.00 420.66 186.47\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(0.972222 0.972222) rotate(0) translate(4 182.47)\">\n",
        "<title>bigraph</title>\n",
-       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-271.31 381.66,-271.31 381.66,4 -4,4\"/>\n",
-       "<!-- (&#39;event_process&#39;, &#39;interval&#39;) -->\n",
-       "<g id=\"node1\" class=\"node\">\n",
-       "<title>(&#39;event_process&#39;, &#39;interval&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"72.08\" cy=\"-25.92\" rx=\"25.92\" ry=\"25.92\"/>\n",
-       "<text text-anchor=\"start\" x=\"53.76\" y=\"-22.32\" font-family=\"Times,serif\" font-size=\"12.00\">interval</text>\n",
-       "</g>\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-182.47 416.66,-182.47 416.66,4 -4,4\"/>\n",
        "<!-- (&#39;mRNA_store&#39;,) -->\n",
-       "<g id=\"node2\" class=\"node\">\n",
+       "<g id=\"node1\" class=\"node\">\n",
        "<title>(&#39;mRNA_store&#39;,)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"42.08\" cy=\"-225.23\" rx=\"42.08\" ry=\"42.08\"/>\n",
-       "<text text-anchor=\"start\" x=\"10.08\" y=\"-221.63\" font-family=\"Times,serif\" font-size=\"12.00\">mRNA_store</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"42.08\" cy=\"-136.39\" rx=\"42.08\" ry=\"42.08\"/>\n",
+       "<text text-anchor=\"start\" x=\"10.08\" y=\"-132.79\" font-family=\"Times,serif\" font-size=\"12.00\">mRNA_store</text>\n",
        "</g>\n",
        "<!-- (&#39;event_process&#39;,) -->\n",
        "<g id=\"node6\" class=\"node\">\n",
        "<title>(&#39;event_process&#39;,)</title>\n",
-       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"109.67,-130.99 34.5,-130.99 34.5,-94.99 109.67,-94.99 109.67,-130.99\"/>\n",
-       "<text text-anchor=\"start\" x=\"38.1\" y=\"-109.39\" font-family=\"Times,serif\" font-size=\"12.00\">event_process</text>\n",
+       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"109.67,-42.15 34.5,-42.15 34.5,-6.15 109.67,-6.15 109.67,-42.15\"/>\n",
+       "<text text-anchor=\"start\" x=\"38.1\" y=\"-20.55\" font-family=\"Times,serif\" font-size=\"12.00\">event_process</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,) -->\n",
-       "<g id=\"edge4\" class=\"edge\">\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
        "<title>(&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M21.11,-187.95C17.5,-177.14 16.28,-165.43 21.19,-155.14 24.01,-149.23 28.15,-143.9 32.86,-139.18\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"34.88,-142.06 40.06,-132.82 30.25,-136.81 34.88,-142.06\"/>\n",
-       "<text text-anchor=\"start\" x=\"22.08\" y=\"-157.14\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M21.11,-99.11C17.5,-88.3 16.28,-76.6 21.19,-66.31 24.01,-60.39 28.15,-55.06 32.86,-50.34\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"34.88,-53.22 40.06,-43.98 30.25,-47.97 34.88,-53.22\"/>\n",
+       "<text text-anchor=\"start\" x=\"22.08\" y=\"-68.31\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,) -->\n",
-       "<g id=\"edge6\" class=\"edge\">\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
        "<title>(&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M56.09,-172.74C60.08,-158.1 64.16,-143.11 67.2,-131.93\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"52.73,-171.78 53.48,-182.34 59.48,-173.61 52.73,-171.78\"/>\n",
-       "<text text-anchor=\"start\" x=\"61.08\" y=\"-157.14\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M56.09,-83.9C60.08,-69.26 64.16,-54.27 67.2,-43.1\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"52.73,-82.94 53.48,-93.51 59.48,-84.78 52.73,-82.94\"/>\n",
+       "<text text-anchor=\"start\" x=\"61.08\" y=\"-68.31\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,) -->\n",
-       "<g id=\"node3\" class=\"node\">\n",
+       "<g id=\"node2\" class=\"node\">\n",
        "<title>(&#39;DNA_store&#39;,)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"161.08\" cy=\"-225.23\" rx=\"36.96\" ry=\"36.96\"/>\n",
-       "<text text-anchor=\"start\" x=\"133.42\" y=\"-221.63\" font-family=\"Times,serif\" font-size=\"12.00\">DNA_store</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"161.08\" cy=\"-136.39\" rx=\"36.96\" ry=\"36.96\"/>\n",
+       "<text text-anchor=\"start\" x=\"133.42\" y=\"-132.79\" font-family=\"Times,serif\" font-size=\"12.00\">DNA_store</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;, &#39;A gene&#39;) -->\n",
-       "<g id=\"node4\" class=\"node\">\n",
+       "<g id=\"node3\" class=\"node\">\n",
        "<title>(&#39;DNA_store&#39;, &#39;A gene&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"161.08\" cy=\"-112.99\" rx=\"24.15\" ry=\"24.15\"/>\n",
-       "<text text-anchor=\"start\" x=\"144.25\" y=\"-109.39\" font-family=\"Times,serif\" font-size=\"12.00\">A gene</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"161.08\" cy=\"-24.15\" rx=\"24.15\" ry=\"24.15\"/>\n",
+       "<text text-anchor=\"start\" x=\"144.25\" y=\"-20.55\" font-family=\"Times,serif\" font-size=\"12.00\">A gene</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;A gene&#39;) -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
        "<title>(&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;A gene&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M161.08,-187.52C161.08,-171.24 161.08,-152.53 161.08,-138.06\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M161.08,-98.68C161.08,-82.4 161.08,-63.69 161.08,-49.22\"/>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;, &#39;B gene&#39;) -->\n",
-       "<g id=\"node5\" class=\"node\">\n",
+       "<g id=\"node4\" class=\"node\">\n",
        "<title>(&#39;DNA_store&#39;, &#39;B gene&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"227.08\" cy=\"-112.99\" rx=\"24.15\" ry=\"24.15\"/>\n",
-       "<text text-anchor=\"start\" x=\"210.25\" y=\"-109.39\" font-family=\"Times,serif\" font-size=\"12.00\">B gene</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"227.08\" cy=\"-24.15\" rx=\"24.15\" ry=\"24.15\"/>\n",
+       "<text text-anchor=\"start\" x=\"210.25\" y=\"-20.55\" font-family=\"Times,serif\" font-size=\"12.00\">B gene</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;B gene&#39;) -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
        "<title>(&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;B gene&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M180,-192.64C191.12,-174.06 204.87,-151.09 214.63,-134.78\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M180,-103.8C191.12,-85.22 204.87,-62.25 214.63,-45.95\"/>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,) -->\n",
-       "<g id=\"edge5\" class=\"edge\">\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
        "<title>(&#39;DNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M137.93,-195.55C124.2,-178.54 106.91,-157.13 93.5,-140.51\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"96.44,-138.59 87.44,-133.01 91,-142.99 96.44,-138.59\"/>\n",
-       "<text text-anchor=\"start\" x=\"112.08\" y=\"-157.14\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M137.93,-106.71C124.2,-89.7 106.91,-68.29 93.5,-51.68\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"96.44,-49.76 87.44,-44.17 91,-54.15 96.44,-49.76\"/>\n",
+       "<text text-anchor=\"start\" x=\"112.08\" y=\"-68.31\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
        "</g>\n",
-       "<!-- (&#39;event_process&#39;,)&#45;&gt;(&#39;event_process&#39;, &#39;interval&#39;) -->\n",
-       "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>(&#39;event_process&#39;,)&#45;&gt;(&#39;event_process&#39;, &#39;interval&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M72.08,-94.36C72.08,-82.29 72.08,-66.09 72.08,-52.6\"/>\n",
+       "<!-- (&#39;emitter&#39;,) -->\n",
+       "<g id=\"node5\" class=\"node\">\n",
+       "<title>(&#39;emitter&#39;,)</title>\n",
+       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"270.08,-154.39 216.08,-154.39 216.08,-118.39 270.08,-118.39 270.08,-154.39\"/>\n",
+       "<text text-anchor=\"start\" x=\"226.09\" y=\"-132.79\" font-family=\"Times,serif\" font-size=\"12.00\">emitter</text>\n",
        "</g>\n",
        "<!-- (&#39;interval_process&#39;,) -->\n",
        "<g id=\"node7\" class=\"node\">\n",
        "<title>(&#39;interval_process&#39;,)</title>\n",
-       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"355,-130.99 269.16,-130.99 269.16,-94.99 355,-94.99 355,-130.99\"/>\n",
-       "<text text-anchor=\"start\" x=\"272.76\" y=\"-109.39\" font-family=\"Times,serif\" font-size=\"12.00\">interval_process</text>\n",
+       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"390,-42.15 304.16,-42.15 304.16,-6.15 390,-6.15 390,-42.15\"/>\n",
+       "<text text-anchor=\"start\" x=\"307.76\" y=\"-20.55\" font-family=\"Times,serif\" font-size=\"12.00\">interval_process</text>\n",
        "</g>\n",
        "<!-- (&#39;interval_process&#39;, &#39;D&#39;, &#39;N&#39;, &#39;A&#39;) -->\n",
        "<!-- (&#39;interval_process&#39;, &#39;D&#39;, &#39;N&#39;, &#39;A&#39;)&#45;&gt;(&#39;interval_process&#39;,) -->\n",
-       "<g id=\"edge7\" class=\"edge\">\n",
+       "<g id=\"edge6\" class=\"edge\">\n",
        "<title>(&#39;interval_process&#39;, &#39;D&#39;, &#39;N&#39;, &#39;A&#39;)&#45;&gt;(&#39;interval_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M272.01,-200.26C275.24,-186.69 280.04,-169.6 286.42,-155.14 289.95,-147.13 294.85,-138.84 299.42,-131.81\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"268.68,-199.11 269.92,-209.64 275.51,-200.64 268.68,-199.11\"/>\n",
-       "<text text-anchor=\"start\" x=\"287.08\" y=\"-157.14\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M307.01,-111.42C310.24,-97.85 315.04,-80.76 321.42,-66.31 324.95,-58.29 329.85,-50 334.42,-42.97\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"303.68,-110.28 304.92,-120.8 310.51,-111.8 303.68,-110.28\"/>\n",
+       "<text text-anchor=\"start\" x=\"322.08\" y=\"-68.31\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
        "</g>\n",
        "<!-- (&#39;interval_process&#39;, &#39;m&#39;, &#39;R&#39;, &#39;N&#39;, &#39;A&#39;) -->\n",
        "<!-- (&#39;interval_process&#39;, &#39;m&#39;, &#39;R&#39;, &#39;N&#39;, &#39;A&#39;)&#45;&gt;(&#39;interval_process&#39;,) -->\n",
-       "<g id=\"edge8\" class=\"edge\">\n",
+       "<g id=\"edge7\" class=\"edge\">\n",
        "<title>(&#39;interval_process&#39;, &#39;m&#39;, &#39;R&#39;, &#39;N&#39;, &#39;A&#39;)&#45;&gt;(&#39;interval_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M312.08,-199.38C312.08,-178.76 312.08,-149.94 312.08,-131.63\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"308.58,-199.2 312.08,-209.2 315.58,-199.2 308.58,-199.2\"/>\n",
-       "<text text-anchor=\"start\" x=\"312.08\" y=\"-157.14\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M347.08,-110.54C347.08,-89.92 347.08,-61.11 347.08,-42.79\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"343.58,-110.36 347.08,-120.36 350.58,-110.36 343.58,-110.36\"/>\n",
+       "<text text-anchor=\"start\" x=\"347.08\" y=\"-68.31\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
        "</g>\n",
        "<!-- (&#39;interval_process&#39;, &#39;i&#39;, &#39;n&#39;, &#39;t&#39;, &#39;e&#39;, &#39;r&#39;, &#39;v&#39;, &#39;a&#39;, &#39;l&#39;) -->\n",
        "<!-- (&#39;interval_process&#39;, &#39;i&#39;, &#39;n&#39;, &#39;t&#39;, &#39;e&#39;, &#39;r&#39;, &#39;v&#39;, &#39;a&#39;, &#39;l&#39;)&#45;&gt;(&#39;interval_process&#39;,) -->\n",
-       "<g id=\"edge9\" class=\"edge\">\n",
+       "<g id=\"edge8\" class=\"edge\">\n",
        "<title>(&#39;interval_process&#39;, &#39;i&#39;, &#39;n&#39;, &#39;t&#39;, &#39;e&#39;, &#39;r&#39;, &#39;v&#39;, &#39;a&#39;, &#39;l&#39;)&#45;&gt;(&#39;interval_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M358.45,-200.09C354.77,-186.47 349.3,-169.39 342.08,-155.14 337.93,-146.94 332.2,-138.61 326.86,-131.61\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"354.99,-200.71 360.84,-209.54 361.78,-198.99 354.99,-200.71\"/>\n",
-       "<text text-anchor=\"start\" x=\"346.08\" y=\"-157.14\" font-family=\"Times,serif\" font-size=\"10.00\">interval</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M393.45,-111.25C389.77,-97.64 384.3,-80.55 377.08,-66.31 372.93,-58.1 367.2,-49.77 361.86,-42.77\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"389.99,-111.87 395.84,-120.7 396.78,-110.15 389.99,-111.87\"/>\n",
+       "<text text-anchor=\"start\" x=\"381.08\" y=\"-68.31\" font-family=\"Times,serif\" font-size=\"10.00\">interval</text>\n",
        "</g>\n",
        "</g>\n",
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x106c111c0>"
+       "<graphviz.graphs.Digraph at 0x10640c8b0>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -688,9 +900,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "id": "a5a1f48a-41aa-4768-b931-ad268495d836",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:36.010180Z",
+     "start_time": "2024-03-05T01:06:36.007521Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# to connect a port in a more targeted way, use connect and specify the port and its target path\n",
@@ -702,9 +919,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "id": "b21b54ae-49e8-47ad-bc88-1327a8e9d230",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:36.030350Z",
+     "start_time": "2024-03-05T01:06:36.010948Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -715,140 +937,141 @@
        "<!-- Generated by graphviz version 9.0.0 (0)\n",
        " -->\n",
        "<!-- Title: bigraph Pages: 1 -->\n",
-       "<svg width=\"404pt\" height=\"370pt\"\n",
-       " viewBox=\"0.00 0.00 415.03 380.52\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
-       "<g id=\"graph0\" class=\"graph\" transform=\"scale(0.972222 0.972222) rotate(0) translate(4 376.52)\">\n",
+       "<svg width=\"521pt\" height=\"195pt\"\n",
+       " viewBox=\"0.00 0.00 535.41 200.68\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(0.972222 0.972222) rotate(0) translate(4 196.68)\">\n",
        "<title>bigraph</title>\n",
-       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-376.52 411.03,-376.52 411.03,4 -4,4\"/>\n",
-       "<!-- (&#39;event_process&#39;, &#39;interval&#39;) -->\n",
-       "<g id=\"node1\" class=\"node\">\n",
-       "<title>(&#39;event_process&#39;, &#39;interval&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"217.37\" cy=\"-107.92\" rx=\"25.92\" ry=\"25.92\"/>\n",
-       "<text text-anchor=\"start\" x=\"199.04\" y=\"-104.32\" font-family=\"Times,serif\" font-size=\"12.00\">interval</text>\n",
-       "</g>\n",
-       "<!-- (&#39;interval_process&#39;,) -->\n",
-       "<g id=\"node9\" class=\"node\">\n",
-       "<title>(&#39;interval_process&#39;,)</title>\n",
-       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"260.29,-36 174.45,-36 174.45,0 260.29,0 260.29,-36\"/>\n",
-       "<text text-anchor=\"start\" x=\"178.05\" y=\"-14.4\" font-family=\"Times,serif\" font-size=\"12.00\">interval_process</text>\n",
-       "</g>\n",
-       "<!-- (&#39;event_process&#39;, &#39;interval&#39;)&#45;&gt;(&#39;interval_process&#39;,) -->\n",
-       "<g id=\"edge11\" class=\"edge\">\n",
-       "<title>(&#39;event_process&#39;, &#39;interval&#39;)&#45;&gt;(&#39;interval_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M217.37,-69.57C217.37,-58.26 217.37,-46.34 217.37,-36.92\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"213.87,-69.5 217.37,-79.5 220.87,-69.5 213.87,-69.5\"/>\n",
-       "<text text-anchor=\"start\" x=\"217.37\" y=\"-56\" font-family=\"Times,serif\" font-size=\"10.00\">interval</text>\n",
-       "</g>\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-196.68 531.41,-196.68 531.41,4 -4,4\"/>\n",
        "<!-- (&#39;mRNA_store&#39;,) -->\n",
-       "<g id=\"node2\" class=\"node\">\n",
+       "<g id=\"node1\" class=\"node\">\n",
        "<title>(&#39;mRNA_store&#39;,)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"130.37\" cy=\"-330.43\" rx=\"42.08\" ry=\"42.08\"/>\n",
-       "<text text-anchor=\"start\" x=\"98.37\" y=\"-326.83\" font-family=\"Times,serif\" font-size=\"12.00\">mRNA_store</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"145.26\" cy=\"-150.6\" rx=\"42.08\" ry=\"42.08\"/>\n",
+       "<text text-anchor=\"start\" x=\"113.26\" y=\"-147\" font-family=\"Times,serif\" font-size=\"12.00\">mRNA_store</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;, &#39;A mRNA&#39;) -->\n",
-       "<g id=\"node3\" class=\"node\">\n",
+       "<g id=\"node2\" class=\"node\">\n",
        "<title>(&#39;mRNA_store&#39;, &#39;A mRNA&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"49.37\" cy=\"-211.09\" rx=\"31.26\" ry=\"31.26\"/>\n",
-       "<text text-anchor=\"start\" x=\"26.53\" y=\"-207.49\" font-family=\"Times,serif\" font-size=\"12.00\">A mRNA</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"31.26\" cy=\"-31.26\" rx=\"31.26\" ry=\"31.26\"/>\n",
+       "<text text-anchor=\"start\" x=\"8.42\" y=\"-27.66\" font-family=\"Times,serif\" font-size=\"12.00\">A mRNA</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;,)&#45;&gt;(&#39;mRNA_store&#39;, &#39;A mRNA&#39;) -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
        "<title>(&#39;mRNA_store&#39;,)&#45;&gt;(&#39;mRNA_store&#39;, &#39;A mRNA&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M106.5,-294.86C93.9,-276.61 78.7,-254.59 67.15,-237.85\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M115.9,-119.38C96.24,-99.14 70.79,-72.95 52.95,-54.59\"/>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;, &#39;B mRNA&#39;) -->\n",
-       "<g id=\"node4\" class=\"node\">\n",
+       "<g id=\"node3\" class=\"node\">\n",
        "<title>(&#39;mRNA_store&#39;, &#39;B mRNA&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"130.37\" cy=\"-211.09\" rx=\"31.25\" ry=\"31.25\"/>\n",
-       "<text text-anchor=\"start\" x=\"107.53\" y=\"-207.49\" font-family=\"Times,serif\" font-size=\"12.00\">B mRNA</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"112.26\" cy=\"-31.26\" rx=\"31.25\" ry=\"31.25\"/>\n",
+       "<text text-anchor=\"start\" x=\"89.42\" y=\"-27.66\" font-family=\"Times,serif\" font-size=\"12.00\">B mRNA</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;,)&#45;&gt;(&#39;mRNA_store&#39;, &#39;B mRNA&#39;) -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
        "<title>(&#39;mRNA_store&#39;,)&#45;&gt;(&#39;mRNA_store&#39;, &#39;B mRNA&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M130.37,-287.4C130.37,-272.8 130.37,-256.71 130.37,-243.16\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M131.97,-109.67C129.97,-103.29 128,-96.74 126.26,-90.51 123.73,-81.5 121.25,-71.62 119.09,-62.6\"/>\n",
        "</g>\n",
        "<!-- (&#39;event_process&#39;,) -->\n",
        "<g id=\"node8\" class=\"node\">\n",
        "<title>(&#39;event_process&#39;,)</title>\n",
-       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"254.96,-229.09 179.78,-229.09 179.78,-193.09 254.96,-193.09 254.96,-229.09\"/>\n",
-       "<text text-anchor=\"start\" x=\"183.38\" y=\"-207.49\" font-family=\"Times,serif\" font-size=\"12.00\">event_process</text>\n",
+       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"236.84,-49.26 161.67,-49.26 161.67,-13.26 236.84,-13.26 236.84,-49.26\"/>\n",
+       "<text text-anchor=\"start\" x=\"165.27\" y=\"-27.66\" font-family=\"Times,serif\" font-size=\"12.00\">event_process</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,) -->\n",
-       "<g id=\"edge6\" class=\"edge\">\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
        "<title>(&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M146.37,-290.66C151.44,-280.36 157.56,-269.54 164.48,-260.35 170.68,-252.11 178.42,-244.14 186.04,-237.13\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"187.88,-240.18 193.06,-230.94 183.25,-234.93 187.88,-240.18\"/>\n",
-       "<text text-anchor=\"start\" x=\"165.37\" y=\"-262.35\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M164.75,-112.31C168.35,-105.12 171.99,-97.62 175.26,-90.51 179.68,-80.87 184.2,-70.16 188.11,-60.59\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"191.32,-61.99 191.8,-51.41 184.82,-59.38 191.32,-61.99\"/>\n",
+       "<text text-anchor=\"start\" x=\"180.26\" y=\"-82.51\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,) -->\n",
-       "<g id=\"edge10\" class=\"edge\">\n",
+       "<g id=\"edge9\" class=\"edge\">\n",
        "<title>(&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M171.47,-295.75C179.41,-287.98 187.17,-279.33 193.37,-270.35 201.94,-257.93 208.25,-241.97 212.24,-229.9\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"169.52,-292.79 164.63,-302.19 174.31,-297.89 169.52,-292.79\"/>\n",
-       "<text text-anchor=\"start\" x=\"199.37\" y=\"-262.35\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M137.83,-97.29C138.52,-91.47 139.94,-85.76 142.36,-80.51 148.02,-68.29 158.48,-58.03 168.89,-50.16\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"134.35,-96.87 137.38,-107.02 141.34,-97.19 134.35,-96.87\"/>\n",
+       "<text text-anchor=\"start\" x=\"143.26\" y=\"-82.51\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
+       "</g>\n",
+       "<!-- (&#39;interval_process&#39;,) -->\n",
+       "<g id=\"node9\" class=\"node\">\n",
+       "<title>(&#39;interval_process&#39;,)</title>\n",
+       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"344.18,-49.26 258.34,-49.26 258.34,-13.26 344.18,-13.26 344.18,-49.26\"/>\n",
+       "<text text-anchor=\"start\" x=\"261.94\" y=\"-27.66\" font-family=\"Times,serif\" font-size=\"12.00\">interval_process</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;,)&#45;&gt;(&#39;interval_process&#39;,) -->\n",
-       "<g id=\"edge9\" class=\"edge\">\n",
+       "<g id=\"edge8\" class=\"edge\">\n",
        "<title>(&#39;mRNA_store&#39;,)&#45;&gt;(&#39;interval_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M91.21,-313.21C62.78,-299.09 26.42,-275.64 9.37,-242.35 -3.3,-217.62 -2.87,-204.78 9.37,-179.84 41.73,-113.9 115.59,-67.31 165.99,-41.79\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"167.28,-45.06 174.7,-37.49 164.18,-38.78 167.28,-45.06\"/>\n",
-       "<text text-anchor=\"start\" x=\"26.37\" y=\"-153.84\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M179.11,-124.13C205.6,-104.2 242.23,-76.65 268.46,-56.93\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"270.51,-59.76 276.4,-50.95 266.31,-54.17 270.51,-59.76\"/>\n",
+       "<text text-anchor=\"start\" x=\"233.26\" y=\"-82.51\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,) -->\n",
-       "<g id=\"node5\" class=\"node\">\n",
+       "<g id=\"node4\" class=\"node\">\n",
        "<title>(&#39;DNA_store&#39;,)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"333.37\" cy=\"-330.43\" rx=\"36.96\" ry=\"36.96\"/>\n",
-       "<text text-anchor=\"start\" x=\"305.71\" y=\"-326.83\" font-family=\"Times,serif\" font-size=\"12.00\">DNA_store</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"418.26\" cy=\"-150.6\" rx=\"36.96\" ry=\"36.96\"/>\n",
+       "<text text-anchor=\"start\" x=\"390.59\" y=\"-147\" font-family=\"Times,serif\" font-size=\"12.00\">DNA_store</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;, &#39;A gene&#39;) -->\n",
-       "<g id=\"node6\" class=\"node\">\n",
+       "<g id=\"node5\" class=\"node\">\n",
        "<title>(&#39;DNA_store&#39;, &#39;A gene&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"297.37\" cy=\"-211.09\" rx=\"24.15\" ry=\"24.15\"/>\n",
-       "<text text-anchor=\"start\" x=\"280.54\" y=\"-207.49\" font-family=\"Times,serif\" font-size=\"12.00\">A gene</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"503.26\" cy=\"-31.26\" rx=\"24.15\" ry=\"24.15\"/>\n",
+       "<text text-anchor=\"start\" x=\"486.43\" y=\"-27.66\" font-family=\"Times,serif\" font-size=\"12.00\">A gene</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;A gene&#39;) -->\n",
-       "<g id=\"edge4\" class=\"edge\">\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
        "<title>(&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;A gene&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M322.57,-294.23C316.69,-275.06 309.58,-251.88 304.41,-235.05\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M439.93,-119.68C455.37,-98.36 475.69,-70.31 489.1,-51.8\"/>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;, &#39;B gene&#39;) -->\n",
-       "<g id=\"node7\" class=\"node\">\n",
+       "<g id=\"node6\" class=\"node\">\n",
        "<title>(&#39;DNA_store&#39;, &#39;B gene&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"363.37\" cy=\"-211.09\" rx=\"24.15\" ry=\"24.15\"/>\n",
-       "<text text-anchor=\"start\" x=\"346.54\" y=\"-207.49\" font-family=\"Times,serif\" font-size=\"12.00\">B gene</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"437.26\" cy=\"-31.26\" rx=\"24.15\" ry=\"24.15\"/>\n",
+       "<text text-anchor=\"start\" x=\"420.43\" y=\"-27.66\" font-family=\"Times,serif\" font-size=\"12.00\">B gene</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;B gene&#39;) -->\n",
-       "<g id=\"edge5\" class=\"edge\">\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
        "<title>(&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;B gene&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M342.45,-293.91C347.31,-274.89 353.17,-252 357.44,-235.28\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M424.16,-113.11C427.19,-94.41 430.79,-72.18 433.45,-55.77\"/>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,) -->\n",
-       "<g id=\"edge7\" class=\"edge\">\n",
+       "<g id=\"edge6\" class=\"edge\">\n",
        "<title>(&#39;DNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M307.34,-303.1C288.13,-283.68 262.13,-257.38 243.02,-238.04\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"245.62,-235.69 236.1,-231.04 240.64,-240.61 245.62,-235.69\"/>\n",
-       "<text text-anchor=\"start\" x=\"272.37\" y=\"-262.35\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M392.59,-123.28C376.79,-108.57 355.38,-91.11 333.26,-80.51 298.82,-64.02 284.75,-76.59 249.26,-62.51 244.51,-60.63 239.7,-58.32 235.04,-55.82\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"236.86,-52.83 226.44,-50.9 233.38,-58.91 236.86,-52.83\"/>\n",
+       "<text text-anchor=\"start\" x=\"349.26\" y=\"-82.51\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,)&#45;&gt;(&#39;interval_process&#39;,) -->\n",
-       "<g id=\"edge8\" class=\"edge\">\n",
+       "<g id=\"edge7\" class=\"edge\">\n",
        "<title>(&#39;DNA_store&#39;,)&#45;&gt;(&#39;interval_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M359.35,-302.93C373.26,-286.85 389.01,-265.07 396.37,-242.35 404.93,-215.92 407.68,-205.21 396.37,-179.84 368.67,-117.71 303.8,-69.55 260.24,-42.72\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"262.15,-39.78 251.78,-37.62 258.54,-45.78 262.15,-39.78\"/>\n",
-       "<text text-anchor=\"start\" x=\"385.37\" y=\"-153.84\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M403.1,-116.07C396.58,-103.97 388.17,-90.78 378.26,-80.51 369.27,-71.21 358.14,-62.91 347.17,-55.94\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"349.28,-53.12 338.91,-50.94 345.65,-59.11 349.28,-53.12\"/>\n",
+       "<text text-anchor=\"start\" x=\"387.26\" y=\"-82.51\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
        "</g>\n",
-       "<!-- (&#39;event_process&#39;,)&#45;&gt;(&#39;event_process&#39;, &#39;interval&#39;) -->\n",
-       "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>(&#39;event_process&#39;,)&#45;&gt;(&#39;event_process&#39;, &#39;interval&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M217.37,-192.47C217.37,-176.51 217.37,-152.78 217.37,-134.69\"/>\n",
+       "<!-- (&#39;emitter&#39;,) -->\n",
+       "<g id=\"node7\" class=\"node\">\n",
+       "<title>(&#39;emitter&#39;,)</title>\n",
+       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"527.26,-168.6 473.26,-168.6 473.26,-132.6 527.26,-132.6 527.26,-168.6\"/>\n",
+       "<text text-anchor=\"start\" x=\"483.26\" y=\"-147\" font-family=\"Times,serif\" font-size=\"12.00\">emitter</text>\n",
+       "</g>\n",
+       "<!-- (&#39;event_process&#39;, &#39;interval&#39;) -->\n",
+       "<g id=\"node10\" class=\"node\">\n",
+       "<title>(&#39;event_process&#39;, &#39;interval&#39;)</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"301.26\" cy=\"-150.6\" rx=\"25.92\" ry=\"25.92\"/>\n",
+       "<text text-anchor=\"start\" x=\"282.93\" y=\"-147\" font-family=\"Times,serif\" font-size=\"12.00\">interval</text>\n",
+       "</g>\n",
+       "<!-- (&#39;event_process&#39;, &#39;interval&#39;)&#45;&gt;(&#39;interval_process&#39;,) -->\n",
+       "<g id=\"edge10\" class=\"edge\">\n",
+       "<title>(&#39;event_process&#39;, &#39;interval&#39;)&#45;&gt;(&#39;interval_process&#39;,)</title>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M301.26,-112.44C301.26,-91.56 301.26,-66.44 301.26,-49.95\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"297.76,-112.33 301.26,-122.33 304.76,-112.33 297.76,-112.33\"/>\n",
+       "<text text-anchor=\"start\" x=\"301.26\" y=\"-82.51\" font-family=\"Times,serif\" font-size=\"10.00\">interval</text>\n",
        "</g>\n",
        "</g>\n",
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x106c2c1c0>"
+       "<graphviz.graphs.Digraph at 0x10640c5b0>"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -867,19 +1090,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "id": "6e00749f-03b8-496e-9a10-106dbac3713f",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:36.034551Z",
+     "start_time": "2024-03-05T01:06:36.031467Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
        "Builder({ 'DNA_store': {'A gene': 0.0, 'B gene': 0.0},\n",
+       "  'emitter': { '_type': 'step',\n",
+       "               'address': 'local:ram-emitter',\n",
+       "               'config': {'emit': {}},\n",
+       "               'inputs': {},\n",
+       "               'instance': <process_bigraph.composite.RAMEmitter object at 0x1063e73d0>,\n",
+       "               'outputs': {}},\n",
        "  'event_process': { '_type': 'process',\n",
        "                     'address': 'local:GillespieEvent',\n",
        "                     'config': {'kdeg': 1.0, 'ktsc': 5.0},\n",
        "                     'inputs': {'DNA': ['DNA_store'], 'mRNA': ['mRNA_store']},\n",
-       "                     'instance': <process_bigraph.experiments.minimal_gillespie.GillespieEvent object at 0x106c12dc0>,\n",
+       "                     'instance': <process_bigraph.experiments.minimal_gillespie.GillespieEvent object at 0x10640b790>,\n",
        "                     'interval': 1.0,\n",
        "                     'outputs': {'mRNA': ['mRNA_store']}},\n",
        "  'interval_process': { '_type': 'step',\n",
@@ -887,12 +1121,12 @@
        "                        'config': {'kdeg': 0.1, 'ktsc': 5.0},\n",
        "                        'inputs': { 'DNA': ['DNA_store'],\n",
        "                                    'mRNA': ['mRNA_store']},\n",
-       "                        'instance': <process_bigraph.experiments.minimal_gillespie.GillespieInterval object at 0x106c118b0>,\n",
+       "                        'instance': <process_bigraph.experiments.minimal_gillespie.GillespieInterval object at 0x10640c220>,\n",
        "                        'outputs': {'interval': ['event_process', 'interval']}},\n",
        "  'mRNA_store': {}})"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -911,9 +1145,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "id": "212f4501-8050-4c39-88b8-986b3c38e716",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:36.037632Z",
+     "start_time": "2024-03-05T01:06:36.035306Z"
+    }
+   },
    "outputs": [],
    "source": [
     "initial_state = {\n",
@@ -922,6 +1161,53 @@
     "        'B gene': 1.0},\n",
     "}\n",
     "b.update(initial_state)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "6b531c8f-e790-4aca-b0a4-77b081dd1fb7",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:36.040913Z",
+     "start_time": "2024-03-05T01:06:36.038385Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Builder({ 'DNA_store': {'A gene': 2.0, 'B gene': 1.0},\n",
+       "  'emitter': { '_type': 'step',\n",
+       "               'address': 'local:ram-emitter',\n",
+       "               'config': {'emit': {}},\n",
+       "               'inputs': {},\n",
+       "               'instance': <process_bigraph.composite.RAMEmitter object at 0x1063e73d0>,\n",
+       "               'outputs': {}},\n",
+       "  'event_process': { '_type': 'process',\n",
+       "                     'address': 'local:GillespieEvent',\n",
+       "                     'config': {'kdeg': 1.0, 'ktsc': 5.0},\n",
+       "                     'inputs': {'DNA': ['DNA_store'], 'mRNA': ['mRNA_store']},\n",
+       "                     'instance': <process_bigraph.experiments.minimal_gillespie.GillespieEvent object at 0x10640b790>,\n",
+       "                     'interval': 1.0,\n",
+       "                     'outputs': {'mRNA': ['mRNA_store']}},\n",
+       "  'interval_process': { '_type': 'step',\n",
+       "                        'address': 'local:GillespieInterval',\n",
+       "                        'config': {'kdeg': 0.1, 'ktsc': 5.0},\n",
+       "                        'inputs': { 'DNA': ['DNA_store'],\n",
+       "                                    'mRNA': ['mRNA_store']},\n",
+       "                        'instance': <process_bigraph.experiments.minimal_gillespie.GillespieInterval object at 0x10640c220>,\n",
+       "                        'outputs': {'interval': ['event_process', 'interval']}},\n",
+       "  'mRNA_store': {'A mRNA': 1.0, 'B mRNA': 1.0}})"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b"
    ]
   },
   {
@@ -934,17 +1220,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 24,
    "id": "e9a69f36-154c-416e-b00c-5df0726be49e",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:36.049438Z",
+     "start_time": "2024-03-05T01:06:36.041610Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "produced interval: {'interval': 1.21174311488629}\n",
-      "received interval: 1.21174311488629\n",
-      "produced interval: {'interval': 30.66671505248375}\n"
+      "produced interval: {'interval': 5.68020763460701}\n",
+      "received interval: 5.68020763460701\n",
+      "produced interval: {'interval': 9.681534786044224}\n"
      ]
     }
    ],
@@ -955,23 +1246,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 25,
    "id": "578492a9-027d-4c5b-b90a-7d63e3f46bc0",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:36.052596Z",
+     "start_time": "2024-03-05T01:06:36.050246Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<process_bigraph.composite.Composite at 0x106c2c700>"
+       "{}"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "composite"
+    "composite.gather_results()"
    ]
   },
   {
@@ -984,11 +1280,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 26,
    "id": "c975aab012b2706f",
    "metadata": {
     "ExecuteTime": {
-     "start_time": "2024-01-21T21:29:21.999855Z"
+     "end_time": "2024-03-05T01:06:36.056239Z",
+     "start_time": "2024-03-05T01:06:36.053317Z"
     },
     "collapsed": false,
     "jupyter": {
@@ -999,23 +1296,28 @@
     {
      "data": {
       "text/plain": [
-       "{'event_process': {'_type': 'process',\n",
+       "{'emitter': {'_type': 'step',\n",
+       "  'address': 'local:ram-emitter',\n",
+       "  'config': {'emit': {}},\n",
+       "  'inputs': {},\n",
+       "  'outputs': {}},\n",
+       " 'event_process': {'_type': 'process',\n",
        "  'address': 'local:GillespieEvent',\n",
        "  'config': {'kdeg': 1.0, 'ktsc': 5.0},\n",
        "  'inputs': {'mRNA': ['mRNA_store'], 'DNA': ['DNA_store']},\n",
        "  'outputs': {'mRNA': ['mRNA_store']},\n",
-       "  'interval': 1.0},\n",
-       " 'mRNA_store': {'A mRNA': '1.0', 'B mRNA': '1.0'},\n",
+       "  'interval': 9.681534786044224},\n",
+       " 'mRNA_store': {'A mRNA': '2.0', 'B mRNA': '1.0'},\n",
        " 'DNA_store': {'A gene': '2.0', 'B gene': '1.0'},\n",
        " 'interval_process': {'_type': 'step',\n",
        "  'address': 'local:GillespieInterval',\n",
        "  'config': {'ktsc': 5.0, 'kdeg': 0.1},\n",
        "  'inputs': {'DNA': ['DNA_store'], 'mRNA': ['mRNA_store']},\n",
        "  'outputs': {'interval': ['event_process', 'interval']}},\n",
-       " 'global_time': '0.0'}"
+       " 'global_time': '10.0'}"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1035,11 +1337,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 27,
    "id": "752e43636bf9fd17",
    "metadata": {
     "ExecuteTime": {
-     "start_time": "2024-01-21T21:29:22.001078Z"
+     "end_time": "2024-03-05T01:06:36.059428Z",
+     "start_time": "2024-03-05T01:06:36.057038Z"
     },
     "collapsed": false,
     "jupyter": {
@@ -1078,33 +1381,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "id": "56b14beb-27de-469d-b4e6-10fc628e15e0",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:36.067311Z",
+     "start_time": "2024-03-05T01:06:36.063319Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Builder({ 'DNA_store': {'A gene': '2.0', 'B gene': '1.0'},\n",
+       "Builder({ 'DNA_store': {'A gene': 2.0, 'B gene': 1.0},\n",
+       "  'emitter': { '_type': 'step',\n",
+       "               'address': 'local:ram-emitter',\n",
+       "               'config': {'emit': {}},\n",
+       "               'inputs': {},\n",
+       "               'instance': <process_bigraph.composite.RAMEmitter object at 0x1064280a0>,\n",
+       "               'outputs': {}},\n",
        "  'event_process': { '_type': 'process',\n",
        "                     'address': 'local:GillespieEvent',\n",
        "                     'config': {'kdeg': 1.0, 'ktsc': 5.0},\n",
        "                     'inputs': {'DNA': ['DNA_store'], 'mRNA': ['mRNA_store']},\n",
-       "                     'instance': <process_bigraph.experiments.minimal_gillespie.GillespieEvent object at 0x105271250>,\n",
-       "                     'interval': 1.0,\n",
+       "                     'instance': <process_bigraph.experiments.minimal_gillespie.GillespieEvent object at 0x106428220>,\n",
+       "                     'interval': 9.681534786044224,\n",
        "                     'outputs': {'mRNA': ['mRNA_store']}},\n",
-       "  'global_time': '0.0',\n",
+       "  'global_time': '10.0',\n",
        "  'interval_process': { '_type': 'step',\n",
        "                        'address': 'local:GillespieInterval',\n",
        "                        'config': {'kdeg': 0.1, 'ktsc': 5.0},\n",
        "                        'inputs': { 'DNA': ['DNA_store'],\n",
        "                                    'mRNA': ['mRNA_store']},\n",
-       "                        'instance': <process_bigraph.experiments.minimal_gillespie.GillespieInterval object at 0x105271130>,\n",
+       "                        'instance': <process_bigraph.experiments.minimal_gillespie.GillespieInterval object at 0x106428970>,\n",
        "                        'outputs': {'interval': ['event_process', 'interval']}},\n",
-       "  'mRNA_store': {'A mRNA': '1.0', 'B mRNA': '1.0'}})"
+       "  'mRNA_store': {'A mRNA': 2.0, 'B mRNA': 1.0}})"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1116,9 +1430,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "id": "6197f4c3-41ca-468b-929f-cc0ebc1fabe9",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:36.087030Z",
+     "start_time": "2024-03-05T01:06:36.068237Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1129,140 +1448,141 @@
        "<!-- Generated by graphviz version 9.0.0 (0)\n",
        " -->\n",
        "<!-- Title: bigraph Pages: 1 -->\n",
-       "<svg width=\"404pt\" height=\"370pt\"\n",
-       " viewBox=\"0.00 0.00 415.03 380.52\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
-       "<g id=\"graph0\" class=\"graph\" transform=\"scale(0.972222 0.972222) rotate(0) translate(4 376.52)\">\n",
+       "<svg width=\"521pt\" height=\"195pt\"\n",
+       " viewBox=\"0.00 0.00 535.41 200.68\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(0.972222 0.972222) rotate(0) translate(4 196.68)\">\n",
        "<title>bigraph</title>\n",
-       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-376.52 411.03,-376.52 411.03,4 -4,4\"/>\n",
-       "<!-- (&#39;event_process&#39;, &#39;interval&#39;) -->\n",
-       "<g id=\"node1\" class=\"node\">\n",
-       "<title>(&#39;event_process&#39;, &#39;interval&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"217.37\" cy=\"-107.92\" rx=\"25.92\" ry=\"25.92\"/>\n",
-       "<text text-anchor=\"start\" x=\"199.04\" y=\"-104.32\" font-family=\"Times,serif\" font-size=\"12.00\">interval</text>\n",
-       "</g>\n",
-       "<!-- (&#39;interval_process&#39;,) -->\n",
-       "<g id=\"node9\" class=\"node\">\n",
-       "<title>(&#39;interval_process&#39;,)</title>\n",
-       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"260.29,-36 174.45,-36 174.45,0 260.29,0 260.29,-36\"/>\n",
-       "<text text-anchor=\"start\" x=\"178.05\" y=\"-14.4\" font-family=\"Times,serif\" font-size=\"12.00\">interval_process</text>\n",
-       "</g>\n",
-       "<!-- (&#39;event_process&#39;, &#39;interval&#39;)&#45;&gt;(&#39;interval_process&#39;,) -->\n",
-       "<g id=\"edge11\" class=\"edge\">\n",
-       "<title>(&#39;event_process&#39;, &#39;interval&#39;)&#45;&gt;(&#39;interval_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M217.37,-69.57C217.37,-58.26 217.37,-46.34 217.37,-36.92\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"213.87,-69.5 217.37,-79.5 220.87,-69.5 213.87,-69.5\"/>\n",
-       "<text text-anchor=\"start\" x=\"217.37\" y=\"-56\" font-family=\"Times,serif\" font-size=\"10.00\">interval</text>\n",
-       "</g>\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-196.68 531.41,-196.68 531.41,4 -4,4\"/>\n",
        "<!-- (&#39;mRNA_store&#39;,) -->\n",
-       "<g id=\"node2\" class=\"node\">\n",
+       "<g id=\"node1\" class=\"node\">\n",
        "<title>(&#39;mRNA_store&#39;,)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"130.37\" cy=\"-330.43\" rx=\"42.08\" ry=\"42.08\"/>\n",
-       "<text text-anchor=\"start\" x=\"98.37\" y=\"-326.83\" font-family=\"Times,serif\" font-size=\"12.00\">mRNA_store</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"145.26\" cy=\"-150.6\" rx=\"42.08\" ry=\"42.08\"/>\n",
+       "<text text-anchor=\"start\" x=\"113.26\" y=\"-147\" font-family=\"Times,serif\" font-size=\"12.00\">mRNA_store</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;, &#39;A mRNA&#39;) -->\n",
-       "<g id=\"node3\" class=\"node\">\n",
+       "<g id=\"node2\" class=\"node\">\n",
        "<title>(&#39;mRNA_store&#39;, &#39;A mRNA&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"49.37\" cy=\"-211.09\" rx=\"31.26\" ry=\"31.26\"/>\n",
-       "<text text-anchor=\"start\" x=\"26.53\" y=\"-207.49\" font-family=\"Times,serif\" font-size=\"12.00\">A mRNA</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"31.26\" cy=\"-31.26\" rx=\"31.26\" ry=\"31.26\"/>\n",
+       "<text text-anchor=\"start\" x=\"8.42\" y=\"-27.66\" font-family=\"Times,serif\" font-size=\"12.00\">A mRNA</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;,)&#45;&gt;(&#39;mRNA_store&#39;, &#39;A mRNA&#39;) -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
+       "<g id=\"edge1\" class=\"edge\">\n",
        "<title>(&#39;mRNA_store&#39;,)&#45;&gt;(&#39;mRNA_store&#39;, &#39;A mRNA&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M106.5,-294.86C93.9,-276.61 78.7,-254.59 67.15,-237.85\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M115.9,-119.38C96.24,-99.14 70.79,-72.95 52.95,-54.59\"/>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;, &#39;B mRNA&#39;) -->\n",
-       "<g id=\"node4\" class=\"node\">\n",
+       "<g id=\"node3\" class=\"node\">\n",
        "<title>(&#39;mRNA_store&#39;, &#39;B mRNA&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"130.37\" cy=\"-211.09\" rx=\"31.25\" ry=\"31.25\"/>\n",
-       "<text text-anchor=\"start\" x=\"107.53\" y=\"-207.49\" font-family=\"Times,serif\" font-size=\"12.00\">B mRNA</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"112.26\" cy=\"-31.26\" rx=\"31.25\" ry=\"31.25\"/>\n",
+       "<text text-anchor=\"start\" x=\"89.42\" y=\"-27.66\" font-family=\"Times,serif\" font-size=\"12.00\">B mRNA</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;,)&#45;&gt;(&#39;mRNA_store&#39;, &#39;B mRNA&#39;) -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
        "<title>(&#39;mRNA_store&#39;,)&#45;&gt;(&#39;mRNA_store&#39;, &#39;B mRNA&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M130.37,-287.4C130.37,-272.8 130.37,-256.71 130.37,-243.16\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M131.97,-109.67C129.97,-103.29 128,-96.74 126.26,-90.51 123.73,-81.5 121.25,-71.62 119.09,-62.6\"/>\n",
        "</g>\n",
        "<!-- (&#39;event_process&#39;,) -->\n",
        "<g id=\"node8\" class=\"node\">\n",
        "<title>(&#39;event_process&#39;,)</title>\n",
-       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"254.96,-229.09 179.78,-229.09 179.78,-193.09 254.96,-193.09 254.96,-229.09\"/>\n",
-       "<text text-anchor=\"start\" x=\"183.38\" y=\"-207.49\" font-family=\"Times,serif\" font-size=\"12.00\">event_process</text>\n",
+       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"236.84,-49.26 161.67,-49.26 161.67,-13.26 236.84,-13.26 236.84,-49.26\"/>\n",
+       "<text text-anchor=\"start\" x=\"165.27\" y=\"-27.66\" font-family=\"Times,serif\" font-size=\"12.00\">event_process</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,) -->\n",
-       "<g id=\"edge6\" class=\"edge\">\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
        "<title>(&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M146.37,-290.66C151.44,-280.36 157.56,-269.54 164.48,-260.35 170.68,-252.11 178.42,-244.14 186.04,-237.13\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"187.88,-240.18 193.06,-230.94 183.25,-234.93 187.88,-240.18\"/>\n",
-       "<text text-anchor=\"start\" x=\"165.37\" y=\"-262.35\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M164.75,-112.31C168.35,-105.12 171.99,-97.62 175.26,-90.51 179.68,-80.87 184.2,-70.16 188.11,-60.59\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"191.32,-61.99 191.8,-51.41 184.82,-59.38 191.32,-61.99\"/>\n",
+       "<text text-anchor=\"start\" x=\"180.26\" y=\"-82.51\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,) -->\n",
-       "<g id=\"edge10\" class=\"edge\">\n",
+       "<g id=\"edge9\" class=\"edge\">\n",
        "<title>(&#39;mRNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M171.47,-295.75C179.41,-287.98 187.17,-279.33 193.37,-270.35 201.94,-257.93 208.25,-241.97 212.24,-229.9\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"169.52,-292.79 164.63,-302.19 174.31,-297.89 169.52,-292.79\"/>\n",
-       "<text text-anchor=\"start\" x=\"199.37\" y=\"-262.35\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M137.83,-97.29C138.52,-91.47 139.94,-85.76 142.36,-80.51 148.02,-68.29 158.48,-58.03 168.89,-50.16\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"134.35,-96.87 137.38,-107.02 141.34,-97.19 134.35,-96.87\"/>\n",
+       "<text text-anchor=\"start\" x=\"143.26\" y=\"-82.51\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
+       "</g>\n",
+       "<!-- (&#39;interval_process&#39;,) -->\n",
+       "<g id=\"node9\" class=\"node\">\n",
+       "<title>(&#39;interval_process&#39;,)</title>\n",
+       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"344.18,-49.26 258.34,-49.26 258.34,-13.26 344.18,-13.26 344.18,-49.26\"/>\n",
+       "<text text-anchor=\"start\" x=\"261.94\" y=\"-27.66\" font-family=\"Times,serif\" font-size=\"12.00\">interval_process</text>\n",
        "</g>\n",
        "<!-- (&#39;mRNA_store&#39;,)&#45;&gt;(&#39;interval_process&#39;,) -->\n",
-       "<g id=\"edge9\" class=\"edge\">\n",
+       "<g id=\"edge8\" class=\"edge\">\n",
        "<title>(&#39;mRNA_store&#39;,)&#45;&gt;(&#39;interval_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M91.21,-313.21C62.78,-299.09 26.42,-275.64 9.37,-242.35 -3.3,-217.62 -2.87,-204.78 9.37,-179.84 41.73,-113.9 115.59,-67.31 165.99,-41.79\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"167.28,-45.06 174.7,-37.49 164.18,-38.78 167.28,-45.06\"/>\n",
-       "<text text-anchor=\"start\" x=\"26.37\" y=\"-153.84\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M179.11,-124.13C205.6,-104.2 242.23,-76.65 268.46,-56.93\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"270.51,-59.76 276.4,-50.95 266.31,-54.17 270.51,-59.76\"/>\n",
+       "<text text-anchor=\"start\" x=\"233.26\" y=\"-82.51\" font-family=\"Times,serif\" font-size=\"10.00\">mRNA</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,) -->\n",
-       "<g id=\"node5\" class=\"node\">\n",
+       "<g id=\"node4\" class=\"node\">\n",
        "<title>(&#39;DNA_store&#39;,)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"333.37\" cy=\"-330.43\" rx=\"36.96\" ry=\"36.96\"/>\n",
-       "<text text-anchor=\"start\" x=\"305.71\" y=\"-326.83\" font-family=\"Times,serif\" font-size=\"12.00\">DNA_store</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"418.26\" cy=\"-150.6\" rx=\"36.96\" ry=\"36.96\"/>\n",
+       "<text text-anchor=\"start\" x=\"390.59\" y=\"-147\" font-family=\"Times,serif\" font-size=\"12.00\">DNA_store</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;, &#39;A gene&#39;) -->\n",
-       "<g id=\"node6\" class=\"node\">\n",
+       "<g id=\"node5\" class=\"node\">\n",
        "<title>(&#39;DNA_store&#39;, &#39;A gene&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"297.37\" cy=\"-211.09\" rx=\"24.15\" ry=\"24.15\"/>\n",
-       "<text text-anchor=\"start\" x=\"280.54\" y=\"-207.49\" font-family=\"Times,serif\" font-size=\"12.00\">A gene</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"503.26\" cy=\"-31.26\" rx=\"24.15\" ry=\"24.15\"/>\n",
+       "<text text-anchor=\"start\" x=\"486.43\" y=\"-27.66\" font-family=\"Times,serif\" font-size=\"12.00\">A gene</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;A gene&#39;) -->\n",
-       "<g id=\"edge4\" class=\"edge\">\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
        "<title>(&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;A gene&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M322.57,-294.23C316.69,-275.06 309.58,-251.88 304.41,-235.05\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M439.93,-119.68C455.37,-98.36 475.69,-70.31 489.1,-51.8\"/>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;, &#39;B gene&#39;) -->\n",
-       "<g id=\"node7\" class=\"node\">\n",
+       "<g id=\"node6\" class=\"node\">\n",
        "<title>(&#39;DNA_store&#39;, &#39;B gene&#39;)</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"363.37\" cy=\"-211.09\" rx=\"24.15\" ry=\"24.15\"/>\n",
-       "<text text-anchor=\"start\" x=\"346.54\" y=\"-207.49\" font-family=\"Times,serif\" font-size=\"12.00\">B gene</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"437.26\" cy=\"-31.26\" rx=\"24.15\" ry=\"24.15\"/>\n",
+       "<text text-anchor=\"start\" x=\"420.43\" y=\"-27.66\" font-family=\"Times,serif\" font-size=\"12.00\">B gene</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;B gene&#39;) -->\n",
-       "<g id=\"edge5\" class=\"edge\">\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
        "<title>(&#39;DNA_store&#39;,)&#45;&gt;(&#39;DNA_store&#39;, &#39;B gene&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M342.45,-293.91C347.31,-274.89 353.17,-252 357.44,-235.28\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M424.16,-113.11C427.19,-94.41 430.79,-72.18 433.45,-55.77\"/>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,) -->\n",
-       "<g id=\"edge7\" class=\"edge\">\n",
+       "<g id=\"edge6\" class=\"edge\">\n",
        "<title>(&#39;DNA_store&#39;,)&#45;&gt;(&#39;event_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M307.34,-303.1C288.13,-283.68 262.13,-257.38 243.02,-238.04\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"245.62,-235.69 236.1,-231.04 240.64,-240.61 245.62,-235.69\"/>\n",
-       "<text text-anchor=\"start\" x=\"272.37\" y=\"-262.35\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M392.59,-123.28C376.79,-108.57 355.38,-91.11 333.26,-80.51 298.82,-64.02 284.75,-76.59 249.26,-62.51 244.51,-60.63 239.7,-58.32 235.04,-55.82\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"236.86,-52.83 226.44,-50.9 233.38,-58.91 236.86,-52.83\"/>\n",
+       "<text text-anchor=\"start\" x=\"349.26\" y=\"-82.51\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
        "</g>\n",
        "<!-- (&#39;DNA_store&#39;,)&#45;&gt;(&#39;interval_process&#39;,) -->\n",
-       "<g id=\"edge8\" class=\"edge\">\n",
+       "<g id=\"edge7\" class=\"edge\">\n",
        "<title>(&#39;DNA_store&#39;,)&#45;&gt;(&#39;interval_process&#39;,)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M359.35,-302.93C373.26,-286.85 389.01,-265.07 396.37,-242.35 404.93,-215.92 407.68,-205.21 396.37,-179.84 368.67,-117.71 303.8,-69.55 260.24,-42.72\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"262.15,-39.78 251.78,-37.62 258.54,-45.78 262.15,-39.78\"/>\n",
-       "<text text-anchor=\"start\" x=\"385.37\" y=\"-153.84\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M403.1,-116.07C396.58,-103.97 388.17,-90.78 378.26,-80.51 369.27,-71.21 358.14,-62.91 347.17,-55.94\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"349.28,-53.12 338.91,-50.94 345.65,-59.11 349.28,-53.12\"/>\n",
+       "<text text-anchor=\"start\" x=\"387.26\" y=\"-82.51\" font-family=\"Times,serif\" font-size=\"10.00\">DNA</text>\n",
        "</g>\n",
-       "<!-- (&#39;event_process&#39;,)&#45;&gt;(&#39;event_process&#39;, &#39;interval&#39;) -->\n",
-       "<g id=\"edge1\" class=\"edge\">\n",
-       "<title>(&#39;event_process&#39;,)&#45;&gt;(&#39;event_process&#39;, &#39;interval&#39;)</title>\n",
-       "<path fill=\"none\" stroke=\"black\" stroke-width=\"2\" d=\"M217.37,-192.47C217.37,-176.51 217.37,-152.78 217.37,-134.69\"/>\n",
+       "<!-- (&#39;emitter&#39;,) -->\n",
+       "<g id=\"node7\" class=\"node\">\n",
+       "<title>(&#39;emitter&#39;,)</title>\n",
+       "<polygon fill=\"none\" stroke=\"black\" stroke-width=\"2\" points=\"527.26,-168.6 473.26,-168.6 473.26,-132.6 527.26,-132.6 527.26,-168.6\"/>\n",
+       "<text text-anchor=\"start\" x=\"483.26\" y=\"-147\" font-family=\"Times,serif\" font-size=\"12.00\">emitter</text>\n",
+       "</g>\n",
+       "<!-- (&#39;event_process&#39;, &#39;interval&#39;) -->\n",
+       "<g id=\"node10\" class=\"node\">\n",
+       "<title>(&#39;event_process&#39;, &#39;interval&#39;)</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" stroke-width=\"2\" cx=\"301.26\" cy=\"-150.6\" rx=\"25.92\" ry=\"25.92\"/>\n",
+       "<text text-anchor=\"start\" x=\"282.93\" y=\"-147\" font-family=\"Times,serif\" font-size=\"12.00\">interval</text>\n",
+       "</g>\n",
+       "<!-- (&#39;event_process&#39;, &#39;interval&#39;)&#45;&gt;(&#39;interval_process&#39;,) -->\n",
+       "<g id=\"edge10\" class=\"edge\">\n",
+       "<title>(&#39;event_process&#39;, &#39;interval&#39;)&#45;&gt;(&#39;interval_process&#39;,)</title>\n",
+       "<path fill=\"none\" stroke=\"black\" stroke-dasharray=\"5,2\" d=\"M301.26,-112.44C301.26,-91.56 301.26,-66.44 301.26,-49.95\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"297.76,-112.33 301.26,-122.33 304.76,-112.33 297.76,-112.33\"/>\n",
+       "<text text-anchor=\"start\" x=\"301.26\" y=\"-82.51\" font-family=\"Times,serif\" font-size=\"10.00\">interval</text>\n",
        "</g>\n",
        "</g>\n",
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x106bece50>"
+       "<graphviz.graphs.Digraph at 0x106440070>"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1275,7 +1595,12 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6c11fc1f-23ee-45e5-9975-f3d3b2e1dff9",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-05T01:06:36.090025Z",
+     "start_time": "2024-03-05T01:06:36.088216Z"
+    }
+   },
    "outputs": [],
    "source": []
   }


### PR DESCRIPTION
This adds `get_dataclass` to the builder, allowing users to access the ProcessConfig data class for any process. Depends on an update to `bigraph-schema`, which need to get merged in before this PR is merged in.